### PR TITLE
[DOC] Add --no-binary to reinstall command

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The easiest way to do so is to define the `CC` variable during the compilation.
 
 ```bash
 $ pip uninstall pillow
-$ CC="cc -mavx2" pip install -U --force-reinstall pillow-simd
+$ CC="cc -mavx2" pip install -U --force-reinstall --no-binary pillow-simd pillow-simd
 ```
 
 


### PR DESCRIPTION
Without this option pillow-simd will not be recompiled if it is already installed. Adding ``--no-binary pillow-simd`` forces the recompile.

I'm not sure if this is the correct branch, contributors guide says to make PRs to master, but I don't see a master branch in the repo.