### PR TITLE
[RBT-284] Added CMYK;16B and CMYK;16N unpackers

### DIFF
--- a/Tests/test_lib_pack.py
+++ b/Tests/test_lib_pack.py
@@ -616,6 +616,14 @@ class TestLibUnpack(PillowTestCase):
             self.assert_unpack("I;16B", "I;16N", 2, 0x0102, 0x0304, 0x0506)
             self.assert_unpack("I;16L", "I;16N", 2, 0x0102, 0x0304, 0x0506)
 
+    def test_CMYK16(self):
+        self.assert_unpack("CMYK", "CMYK;16L", 8, (2, 4, 6, 8), (10, 12, 14, 16))
+        self.assert_unpack("CMYK", "CMYK;16B", 8, (1, 3, 5, 7), (9, 11, 13, 15))
+        if sys.byteorder == "little":
+            self.assert_unpack("CMYK", "CMYK;16N", 8, (2, 4, 6, 8), (10, 12, 14, 16))
+        else:
+            self.assert_unpack("CMYK", "CMYK;16N", 8, (1, 3, 5, 7), (9, 11, 13, 15))
+
     def test_value_error(self):
         self.assertRaises(ValueError, self.assert_unpack, "L", "L", 0, 0)
         self.assertRaises(ValueError, self.assert_unpack, "RGB", "RGB", 2, 0)

--- a/src/libImaging/Unpack.c
+++ b/src/libImaging/Unpack.c
@@ -1428,6 +1428,12 @@ static struct {
     {"CMYK",    "Y;I",          8,      band2I},
     {"CMYK",    "K;I",          8,      band3I},
 
+#ifdef WORDS_BIGENDIAN
+    {"CMYK",    "CMYK;16N",     64,     unpackRGBA16B},
+#else
+    {"CMYK",    "CMYK;16N",     64,     unpackRGBA16L},
+#endif
+
     /* video (YCbCr) */
     {"YCbCr",   "YCbCr",        24,     ImagingUnpackRGB},
     {"YCbCr",   "YCbCr;L",      24,     unpackRGBL},


### PR DESCRIPTION
Issue: https://uploadcare.atlassian.net/browse/RBT-284

Cherry-picked 9c37933bb9756aa9a644530e50fc996916181679 that solves this problem (and is part of 6.1.0)



Changes proposed in this pull request:

 * 
 * 
 * 
