### PR TITLE
Corrected return types

### DIFF
--- a/src/PIL/features.py
+++ b/src/PIL/features.py
@@ -128,7 +128,7 @@ features = {
     "libjpeg_turbo": ("PIL._imaging", "HAVE_LIBJPEGTURBO", "libjpeg_turbo_version"),
     "libimagequant": ("PIL._imaging", "HAVE_LIBIMAGEQUANT", "imagequant_version"),
     "xcb": ("PIL._imaging", "HAVE_XCB", None),
-    "acceleration": ("PIL._imaging", "acceleration", "acceleration"),
+    "acceleration": ("PIL._imaging", "HAVE_ACCELERATION", "acceleration"),
 }
 
 

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -4407,6 +4407,7 @@ setup_module(PyObject *m) {
     Py_INCREF(have_xcb);
     PyModule_AddObject(m, "HAVE_XCB", have_xcb);
 
+    PyObject *have_acceleration = Py_True;
 #ifdef __AVX2__
     PyModule_AddStringConstant(m, "acceleration", "avx2");
 #elif defined(__SSE4__)
@@ -4418,7 +4419,11 @@ setup_module(PyObject *m) {
 #else
     Py_INCREF(Py_False);
     PyModule_AddObject(m, "acceleration", Py_False);
+
+    have_acceleration = Py_False;
 #endif
+    Py_INCREF(have_acceleration);
+    PyModule_AddObject(m, "HAVE_ACCELERATION", have_acceleration);
 
     PyObject *pillow_version = PyUnicode_FromString(version);
     PyDict_SetItemString(

--- a/src/_imaging.c
+++ b/src/_imaging.c
@@ -4417,8 +4417,8 @@ setup_module(PyObject *m) {
 #elif defined(__NEON__)
     PyModule_AddStringConstant(m, "acceleration", "neon");
 #else
-    Py_INCREF(Py_False);
-    PyModule_AddObject(m, "acceleration", Py_False);
+    Py_INCREF(Py_None);
+    PyModule_AddObject(m, "acceleration", Py_None);
 
     have_acceleration = Py_False;
 #endif


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/8209

`check_feature()` should not return a string - https://github.com/python-pillow/Pillow/blob/a5b415bef5bf1f89f6d9bd371da78f9f8ed9eee1/src/PIL/features.py#L134

`version_feature()` should not return a boolean - https://github.com/python-pillow/Pillow/blob/a5b415bef5bf1f89f6d9bd371da78f9f8ed9eee1/src/PIL/features.py#L158