### PR TITLE
Added WebP saving test

### DIFF
--- a/Tests/test_file_webp.py
+++ b/Tests/test_file_webp.py
@@ -127,6 +127,11 @@ class TestFileWebp:
             reloaded.seek(1)
             assert_image_similar(im2, reloaded, 1)
 
+    def test_unsupported_image_mode(self) -> None:
+        im = Image.new("1", (1, 1))
+        with pytest.raises(ValueError):
+            _webp.WebPEncode(im.getim(), False, 0, 0, "", 4, 0, b"", "")
+
     def test_icc_profile(self, tmp_path: Path) -> None:
         self._roundtrip(tmp_path, self.rgb_mode, 12.5, {"icc_profile": None})
         self._roundtrip(

--- a/src/_webp.c
+++ b/src/_webp.c
@@ -89,8 +89,6 @@ HandleMuxError(WebPMuxError err, char *chunk) {
 
 static int
 import_frame_libwebp(WebPPicture *frame, Imaging im) {
-    int drop_alpha = strcmp(im->mode, "RGBA");
-
     if (strcmp(im->mode, "RGBA") && strcmp(im->mode, "RGB") &&
         strcmp(im->mode, "RGBX")) {
         PyErr_SetString(PyExc_ValueError, "unsupported image mode");
@@ -106,10 +104,11 @@ import_frame_libwebp(WebPPicture *frame, Imaging im) {
         return -2;
     }
 
+    int ignore_fourth_channel = strcmp(im->mode, "RGBA");
     for (int y = 0; y < im->ysize; ++y) {
         UINT8 *src = (UINT8 *)im->image32[y];
         UINT32 *dst = frame->argb + frame->argb_stride * y;
-        if (drop_alpha) {
+        if (ignore_fourth_channel) {
             for (int x = 0; x < im->xsize; ++x) {
                 dst[x] =
                     ((UINT32)(src[x * 4 + 2]) | ((UINT32)(src[x * 4 + 1]) << 8) |


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/8386

- Rename 'drop_alpha', since alpha is not being dropped as such. There isn't alpha to drop. I suggest 'ignore_fourth_channel' instead?
- Added a test to raise the "unsupported image mode" error.