### PR TITLE
Use getim()

### DIFF
--- a/Tests/test_imagemorph.py
+++ b/Tests/test_imagemorph.py
@@ -324,17 +324,17 @@ def test_set_lut() -> None:
 
 def test_wrong_mode() -> None:
     lut = ImageMorph.LutBuilder(op_name="corner").build_lut()
-    imrgb = Image.new("RGB", (10, 10))
-    iml = Image.new("L", (10, 10))
+    imrgb_ptr = Image.new("RGB", (10, 10)).getim()
+    iml_ptr = Image.new("L", (10, 10)).getim()
 
     with pytest.raises(RuntimeError):
-        _imagingmorph.apply(bytes(lut), imrgb.getim(), iml.getim())
+        _imagingmorph.apply(bytes(lut), imrgb_ptr, iml_ptr)
 
     with pytest.raises(RuntimeError):
-        _imagingmorph.apply(bytes(lut), iml.getim(), imrgb.getim())
+        _imagingmorph.apply(bytes(lut), iml_ptr, imrgb_ptr)
 
     with pytest.raises(RuntimeError):
-        _imagingmorph.match(bytes(lut), imrgb.getim())
+        _imagingmorph.match(bytes(lut), imrgb_ptr)
 
     # Should not raise
-    _imagingmorph.match(bytes(lut), iml.getim())
+    _imagingmorph.match(bytes(lut), iml_ptr)

--- a/docs/releasenotes/11.0.0.rst
+++ b/docs/releasenotes/11.0.0.rst
@@ -73,6 +73,16 @@ vulnerability introduced in FreeType 2.6 (:cve:`2020-15999`).
 
 .. _2.10.4: https://sourceforge.net/projects/freetype/files/freetype2/2.10.4/
 
+Get Internal Pointers to Objects
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. deprecated:: 11.0.0
+
+``Image.core.ImagingCore.id`` and ``Image.core.ImagingCore.unsafe_ptrs`` have been
+deprecated and will be removed in Pillow 12 (2025-10-15). They were used for obtaining
+raw pointers to ``ImagingCore`` internals. To interact with C code, you can use
+``Image.Image.getim()``, which returns a ``Capsule`` object.
+
 ICNS (width, height, scale) sizes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/PIL/ImageTk.py
+++ b/src/PIL/ImageTk.py
@@ -176,15 +176,14 @@ class PhotoImage:
                    the bitmap image.
         """
         # convert to blittable
-        im.load()
+        ptr = im.getim()
         image = im.im
-        if image.isblock() and im.mode == self.__mode:
-            block = image
-        else:
+        if not image.isblock() or im.mode != self.__mode:
             block = Image.core.new_block(self.__mode, im.size)
             image.convert2(block, image)  # convert directly between buffers
+            ptr = block.ptr
 
-        _pyimagingtkcall("PyImagingPhoto", self.__photo, block.ptr)
+        _pyimagingtkcall("PyImagingPhoto", self.__photo, ptr)
 
 
 # --------------------------------------------------------------------


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/8341

- Copied deprecation documentation to release notes
- In a test, load the image before trying to catch exceptions from a subsequent operation
- Use `getim()` in ImageTk