### PR TITLE
Restrict environment keys for ImageMath.eval()

### DIFF
--- a/Tests/test_imagemath.py
+++ b/Tests/test_imagemath.py
@@ -63,6 +63,16 @@ def test_prevent_exec(expression):
         ImageMath.eval(expression)
 
 
+def test_prevent_double_underscores():
+    with pytest.raises(ValueError):
+        ImageMath.eval("1", {"__": None})
+
+
+def test_prevent_builtins():
+    with pytest.raises(ValueError):
+        ImageMath.eval("(lambda: exec('exit()'))()", {"exec": None})
+
+
 def test_logical():
     assert pixel(ImageMath.eval("not A", images)) == 0
     assert pixel(ImageMath.eval("A and B", images)) == "L 2"

--- a/docs/releasenotes/9.5.0.rst
+++ b/docs/releasenotes/9.5.0.rst
@@ -49,6 +49,14 @@ PLT markers.
 Security
 ========
 
+Restricted environment keys for ImageMath.eval
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:cve:`2023-50447`: If an attacker has control over the keys passed to the
+``environment`` argument of :py:meth:`PIL.ImageMath.eval`, they may be able to execute
+arbitrary code. To prevent this, keys matching the names of builtins and keys
+containing double underscores will now raise a :py:exc:`ValueError`.
+
 Clear PPM half token after use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/PIL/ImageMath.py
+++ b/src/PIL/ImageMath.py
@@ -237,6 +237,11 @@ def eval(expression, _dict={}, **kw):
 
     # build execution namespace
     args = ops.copy()
+    for k in list(_dict.keys()) + list(kw.keys()):
+        if "__" in k or hasattr(builtins, k):
+            msg = f"'{k}' not allowed"
+            raise ValueError(msg)
+
     args.update(_dict)
     args.update(kw)
     for k, v in list(args.items()):


### PR DESCRIPTION
Prevent environment keys matching the names of builtins and keys containing double underscores from being passed to ImageMath.eval(), by raising a ValueError.

This is a cherry-pick of python-pillow/Pillow#7655 to fix CVE-2023-50447 in Pillow-SIMD. Pillow only fixed it in 10.x, but Pillow-SIMD doesn't have that release yet so it's vulnerable. This commit solves that issue.